### PR TITLE
Fix/t1 [Bug] string from STDIN is not chomped

### DIFF
--- a/lib/tasks/aws.rake
+++ b/lib/tasks/aws.rake
@@ -74,5 +74,6 @@ def prompt(item, default:)
   response = STDIN.gets
   return default if response.nil?
 
-  response.chomp.strip.empty? ? default : response
+  chomped_response = response.chomp.strip
+  chomped_response.empty? ? default : chomped_response
 end


### PR DESCRIPTION
close #1 

### Changes

In the method `prompt` at `lib/tasks/aws.rake:L70,` return chomped response string.
This change will fix:

1. `No such file or directory` error after input a specific public key path for `Please enter public_key_location`.
2. No auto_connect after input `y` for `Please enter auto_connect`.